### PR TITLE
Remove Custom Name for soul entity

### DIFF
--- a/TheCollections/src/main/java/com/qualityplus/collections/util/CollectionsPlaceholderUtil.java
+++ b/TheCollections/src/main/java/com/qualityplus/collections/util/CollectionsPlaceholderUtil.java
@@ -33,7 +33,7 @@ public class CollectionsPlaceholderUtil {
 
     public PlaceholderBuilder getCollectionsPlaceholders(UserData userData, Collection skill, int level) {
         double xp = userData.getCollections().getXp(skill.getId());
-        double maxXp = skill.getLevelRequirement(level + 1);
+        double maxXp = skill.getLevelRequirement(level);
         double percentage = ActionBarUtils.getPercentageFromTotal(xp, maxXp);
 
         return PlaceholderBuilder.create(

--- a/TheSouls/src/main/java/com/qualityplus/souls/base/soul/Soul.java
+++ b/TheSouls/src/main/java/com/qualityplus/souls/base/soul/Soul.java
@@ -62,7 +62,7 @@ public final class Soul extends OkaeriConfig {
 
         soulEntity.setInvulnerable(true);
 
-        soulEntity.setCustomName("theSouls");
+        soulEntity.setCustomName("");
 
         soulEntity.setCustomNameVisible(false);
 


### PR DESCRIPTION
The entity name was set to "theSouls". I'm not sure if this was visible on Java but when using GeyserMC with Bedrock, it shows up when the player looks at the soul.

This PR just sets that string to empty and that no longer happens on GeyserMC/Bedrock.