### PR TITLE
Fix deleting recipes, going back in the recipe preview gui and add custom go back item for the main recipe book gui

### DIFF
--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/commands/DeleteRecipeCommand.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/commands/DeleteRecipeCommand.java
@@ -35,7 +35,8 @@ public final class DeleteRecipeCommand extends AssistantCommand {
                 return false;
             }
 
-            box.files().recipes().craftingRecipes.remove(exist);
+            Recipes.removeByID(id);
+            box.files().recipes().saveRecipes();
 
             player.sendMessage(StringUtils.color(box.files().messages().recipeMessages.successfullyDeletedRecipe));
         }else{

--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/config/Inventories.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/config/Inventories.java
@@ -144,6 +144,10 @@ public final class Inventories extends OkaeriConfig implements DefaultBackground
                     "",
                     "&7Recipe Unlocked: &e%recipes_percentage_progress%&6%",
                     "%recipes_progress_actionbar% &e%unlocked_recipes%&6/&e%recipes_total%")).build())
+            .customGoBackItem(ItemBuilder.of(XMaterial.ARROW,  47, 1, "&eGo Back", Arrays.asList("", "&7Click to go back!"))
+                .command("your go back command %player%")
+                .enabled(false)
+                .build())
             .build();
 
     @CustomKey("recipeBookSubGUI")

--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/book/main/RecipeBookMainGUI.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/book/main/RecipeBookMainGUI.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -52,6 +53,7 @@ public final class RecipeBookMainGUI extends CraftingGUI {
             recipeMap.put(category.getSlot(), category);
         }
 
+        Optional.ofNullable(config.getCustomGoBackItem()).ifPresent(this::setItem);
 
         setItem(config.getCloseGUI());
 
@@ -70,8 +72,10 @@ public final class RecipeBookMainGUI extends CraftingGUI {
 
         Player player = (Player) event.getWhoClicked();
 
-        if(isItem(slot, config.getCloseGUI())){
+        if(isItem(slot, config.getCloseGUI())) {
             player.closeInventory();
+        }else if(isItem(slot, config.getCustomGoBackItem())) {
+            handleItemCommandClick(player, config.getCustomGoBackItem());
         }else if(recipeMap.containsKey(slot)){
             Category category = recipeMap.getOrDefault(slot, null);
 

--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/book/main/RecipeBookMainGUIConfig.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/book/main/RecipeBookMainGUIConfig.java
@@ -12,11 +12,13 @@ public final class RecipeBookMainGUIConfig extends OkaeriConfig implements Simpl
     private final Item generalProgressItem;
     private final CommonGUI commonGUI;
     private final Item categoryItem;
+    private final Item customGoBackItem;
 
     @Builder
-    public RecipeBookMainGUIConfig(Item generalProgressItem, CommonGUI commonGUI, Item categoryItem) {
+    public RecipeBookMainGUIConfig(Item generalProgressItem, CommonGUI commonGUI, Item categoryItem, Item customGoBackItem) {
         this.generalProgressItem = generalProgressItem;
         this.commonGUI = commonGUI;
         this.categoryItem = categoryItem;
+        this.customGoBackItem = customGoBackItem;
     }
 }

--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/individual/RecipeIndividualGUI.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/individual/RecipeIndividualGUI.java
@@ -89,6 +89,10 @@ public final class RecipeIndividualGUI extends CraftingGUI {
             player.closeInventory();
             player.sendMessage(StringUtils.color(box.files().messages().recipeMessages.typePage));
             edition.setEditMode(player.getUniqueId(), new EditionObject(recipe, RecipeEdition.EditionType.PAGE));
+        }else if(isItem(slot, config.getDeleteItem())) {
+            player.closeInventory();
+            // Maybe a better way to do this?
+            player.performCommand("thecrafting delete " + recipe.getId());
         }
     }
 

--- a/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/preview/RecipePreviewGUI.java
+++ b/TheCrafting/src/main/java/com/qualityplus/crafting/base/gui/preview/RecipePreviewGUI.java
@@ -56,7 +56,7 @@ public final class RecipePreviewGUI extends CraftingGUI {
             player.closeInventory();
         }else if(isItem(slot, config.getGoBackBook())){
 
-            Category category = box.files().categories().getCategory(recipe.getId());
+            Category category = box.files().categories().getCategory(recipe.getCategory());
 
             if (category == null) {
                 player.sendMessage(StringUtils.color(box.files().messages().recipeMessages.recipeDontBelongAnyCategory));

--- a/TheSkills/src/main/java/com/qualityplus/skills/gui/main/MainGUI.java
+++ b/TheSkills/src/main/java/com/qualityplus/skills/gui/main/MainGUI.java
@@ -74,7 +74,16 @@ public final class MainGUI extends SkillsGUI {
         if(isItem(slot, config.getCloseGUI())) {
             player.closeInventory();
         }else if(isItem(slot, config.getPlayerInfoItem())){
-            player.openInventory(new StatsAndPerksGUI(box, player, 1, StatsAndPerksGUI.GUIType.STAT).getInventory());
+            // This retains the original behaviour for all server owners
+            // as the command is not provided by default but allows more
+            // customization.
+            if(config.getPlayerInfoItem().command != null && !config.getPlayerInfoItem().command.isEmpty()){
+                // A workaround while TheAssistant does not replace
+                // PlaceholderAPI placeholders in item name and lore.
+                handleItemCommandClick(player, config.getPlayerInfoItem());
+            }else{
+                player.openInventory(new StatsAndPerksGUI(box, player, 1, StatsAndPerksGUI.GUIType.STAT).getInventory());
+            }
         }else if(isItem(slot, config.getCustomGoBackItem())){
             handleItemCommandClick(player, config.getCustomGoBackItem());
         }else{


### PR DESCRIPTION
This PR addresses the following:
* Fixes deleting recipes via the `/thecrafting delete` command,
* Fixes (implements) deleting recipes via the gui,
* Fixes going back in the recipe preview gui,
* Adds optional custom go back item for the main recipe book gui.